### PR TITLE
Fix admin dashboard data display issue

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -44,8 +44,20 @@ class AdminController extends Controller
             'success_rates' => $this->getSuccessRatesData()
         ];
 
-        // Pass 'chartData' to the view, which includes 'user_growth'
-        return view('admin.admin', compact('stats', 'chartData'));
+        // Get recent users (last 5)
+        $recentUsers = User::with('profile')
+            ->orderBy('created_at', 'desc')
+            ->limit(5)
+            ->get();
+
+        // Get recent pitches/projects (last 5)
+        $recentPitches = Project::with('user')
+            ->orderBy('created_at', 'desc')
+            ->limit(5)
+            ->get();
+
+        // Pass 'chartData', 'recentUsers', and 'recentPitches' to the view
+        return view('admin.admin', compact('stats', 'chartData', 'recentUsers', 'recentPitches'));
     }
 
     private function getUserGrowthData()
@@ -341,5 +353,21 @@ class AdminController extends Controller
             'totalProjects' => $totalProjects,
             'monthlyUserGrowth' => $monthlyUserGrowth,
         ]);
+    }
+
+    public function viewPitch($id)
+    {
+        try {
+            $project = Project::with('user.profile')->findOrFail($id);
+            return response()->json([
+                'success' => true,
+                'project' => $project
+            ]);
+        } catch (\Exception $e) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Project not found'
+            ], 404);
+        }
     }
 }

--- a/public/css/admin/project-modal.css
+++ b/public/css/admin/project-modal.css
@@ -1,0 +1,319 @@
+/* Modal Styles */
+.modal {
+    display: none;
+    position: fixed;
+    z-index: 1000;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    overflow: auto;
+}
+
+.modal-content {
+    background-color: #fff;
+    margin: 5% auto;
+    padding: 0;
+    border-radius: 8px;
+    width: 90%;
+    max-width: 800px;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    animation: slideDown 0.3s ease-out;
+}
+
+@keyframes slideDown {
+    from {
+        transform: translateY(-50px);
+        opacity: 0;
+    }
+    to {
+        transform: translateY(0);
+        opacity: 1;
+    }
+}
+
+.modal-header {
+    padding: 20px;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    border-radius: 8px 8px 0 0;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.modal-header h3 {
+    margin: 0;
+    font-size: 1.5rem;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.modal-header .close {
+    color: white;
+    font-size: 28px;
+    font-weight: bold;
+    cursor: pointer;
+    transition: all 0.3s;
+}
+
+.modal-header .close:hover,
+.modal-header .close:focus {
+    color: #f1f1f1;
+    transform: scale(1.2);
+}
+
+.modal-body {
+    padding: 30px;
+    max-height: 70vh;
+    overflow-y: auto;
+}
+
+/* Pitch Details Styles */
+.pitch-details {
+    display: flex;
+    flex-direction: column;
+    gap: 25px;
+}
+
+.pitch-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding-bottom: 15px;
+    border-bottom: 2px solid #f0f0f0;
+}
+
+.pitch-header h2 {
+    margin: 0;
+    color: #333;
+    font-size: 1.8rem;
+}
+
+.pitch-info-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 20px;
+    padding: 20px 0;
+}
+
+.pitch-info-item {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+}
+
+.pitch-info-item label {
+    font-weight: 600;
+    color: #666;
+    font-size: 0.9rem;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.pitch-info-item label i {
+    color: #667eea;
+}
+
+.pitch-info-item span {
+    font-size: 1.1rem;
+    color: #333;
+    padding-left: 24px;
+}
+
+.pitch-progress {
+    margin: 20px 0;
+}
+
+.pitch-progress label {
+    font-weight: 600;
+    color: #666;
+    margin-bottom: 10px;
+    display: block;
+}
+
+.progress-bar-container {
+    width: 100%;
+    height: 30px;
+    background-color: #f0f0f0;
+    border-radius: 15px;
+    overflow: hidden;
+    box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.progress-bar-fill {
+    height: 100%;
+    background: linear-gradient(90deg, #667eea 0%, #764ba2 100%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: white;
+    font-weight: 600;
+    transition: width 0.5s ease;
+    min-width: 50px;
+}
+
+.pitch-description {
+    background-color: #f9f9f9;
+    padding: 20px;
+    border-radius: 8px;
+    border-left: 4px solid #667eea;
+}
+
+.pitch-description label {
+    font-weight: 600;
+    color: #666;
+    margin-bottom: 10px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.pitch-description label i {
+    color: #667eea;
+}
+
+.pitch-description p {
+    color: #555;
+    line-height: 1.6;
+    margin: 10px 0 0 0;
+    white-space: pre-wrap;
+}
+
+.pitch-meta {
+    display: flex;
+    justify-content: space-between;
+    padding-top: 20px;
+    border-top: 1px solid #e0e0e0;
+    color: #999;
+    font-size: 0.85rem;
+}
+
+.pitch-meta small {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
+.pitch-meta i {
+    color: #667eea;
+}
+
+/* Status Badges */
+.status-badge {
+    padding: 6px 16px;
+    border-radius: 20px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.status-active {
+    background-color: #e8f5e9;
+    color: #2e7d32;
+}
+
+.status-pending {
+    background-color: #fff3e0;
+    color: #f57c00;
+}
+
+.status-completed {
+    background-color: #e3f2fd;
+    color: #1565c0;
+}
+
+.status-draft {
+    background-color: #f5f5f5;
+    color: #616161;
+}
+
+.status-entrepreneur {
+    background-color: #fce4ec;
+    color: #c2185b;
+}
+
+.status-investor {
+    background-color: #e0f2f1;
+    color: #00695c;
+}
+
+/* Action Buttons */
+.view-btn {
+    background-color: #2196f3;
+    color: white;
+    border: none;
+    padding: 8px 12px;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: all 0.3s;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.view-btn:hover {
+    background-color: #1976d2;
+    transform: translateY(-2px);
+    box-shadow: 0 4px 8px rgba(33, 150, 243, 0.3);
+}
+
+.view-btn i {
+    font-size: 16px;
+}
+
+/* User Info Styles */
+.user-info {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.user-info i {
+    font-size: 20px;
+    color: #667eea;
+}
+
+/* Project Info Styles */
+.project-info {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.project-icon {
+    color: #667eea;
+    font-size: 18px;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+    .modal-content {
+        width: 95%;
+        margin: 10% auto;
+    }
+
+    .pitch-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 10px;
+    }
+
+    .pitch-info-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .pitch-meta {
+        flex-direction: column;
+        gap: 10px;
+    }
+
+    .modal-body {
+        padding: 20px;
+        max-height: 60vh;
+    }
+}

--- a/public/js/admin-dashboard.js
+++ b/public/js/admin-dashboard.js
@@ -205,3 +205,129 @@ document.addEventListener("DOMContentLoaded", function() {
         document.body.classList.add("sidebar-collapsed");
     }
 });
+
+// View Pitch Function
+window.viewPitch = function(pitchId) {
+    fetch(`/admin/projects/${pitchId}/view`, {
+        method: 'GET',
+        headers: {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+            'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.content || ''
+        }
+    })
+    .then(response => response.json())
+    .then(data => {
+        if (data.success) {
+            const project = data.project;
+            const progress = project.funding_goal > 0
+                ? Math.min(100, (project.current_funding / project.funding_goal) * 100)
+                : 0;
+
+            const modalBody = document.getElementById('pitchModalBody');
+            modalBody.innerHTML = `
+                <div class="pitch-details">
+                    <div class="pitch-header">
+                        <h2>${project.title}</h2>
+                        <span class="status-badge status-${project.status.toLowerCase()}">${project.status}</span>
+                    </div>
+
+                    <div class="pitch-info-grid">
+                        <div class="pitch-info-item">
+                            <label><i class="fas fa-user"></i> Author:</label>
+                            <span>${project.user.first_name} ${project.user.last_name}</span>
+                        </div>
+                        <div class="pitch-info-item">
+                            <label><i class="fas fa-tag"></i> Category:</label>
+                            <span>${project.category || 'N/A'}</span>
+                        </div>
+                        <div class="pitch-info-item">
+                            <label><i class="fas fa-bullseye"></i> Funding Goal:</label>
+                            <span>₱${parseFloat(project.funding_goal).toLocaleString()}</span>
+                        </div>
+                        <div class="pitch-info-item">
+                            <label><i class="fas fa-money-bill-wave"></i> Current Funding:</label>
+                            <span>₱${parseFloat(project.current_funding).toLocaleString()}</span>
+                        </div>
+                        <div class="pitch-info-item">
+                            <label><i class="fas fa-calendar-alt"></i> Start Date:</label>
+                            <span>${new Date(project.start_date).toLocaleDateString()}</span>
+                        </div>
+                        <div class="pitch-info-item">
+                            <label><i class="fas fa-calendar-check"></i> End Date:</label>
+                            <span>${new Date(project.end_date).toLocaleDateString()}</span>
+                        </div>
+                    </div>
+
+                    <div class="pitch-progress">
+                        <label>Funding Progress:</label>
+                        <div class="progress-bar-container">
+                            <div class="progress-bar-fill" style="width: ${progress}%">
+                                ${progress.toFixed(0)}%
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="pitch-description">
+                        <label><i class="fas fa-file-alt"></i> Description:</label>
+                        <p>${project.description}</p>
+                    </div>
+
+                    <div class="pitch-meta">
+                        <small><i class="fas fa-clock"></i> Created: ${new Date(project.created_at).toLocaleString()}</small>
+                        <small><i class="fas fa-sync"></i> Updated: ${new Date(project.updated_at).toLocaleString()}</small>
+                    </div>
+                </div>
+            `;
+
+            document.getElementById('pitchViewModal').style.display = 'block';
+        } else {
+            alert('Failed to load pitch details');
+        }
+    })
+    .catch(error => {
+        console.error('Error:', error);
+        alert('Failed to load pitch details');
+    });
+};
+
+// Close Pitch Modal
+window.closePitchModal = function() {
+    document.getElementById('pitchViewModal').style.display = 'none';
+};
+
+// Delete Pitch Function
+window.deletePitch = function(pitchId) {
+    if (confirm('Are you sure you want to delete this pitch? This action cannot be undone.')) {
+        fetch(`/admin/projects/${pitchId}`, {
+            method: 'DELETE',
+            headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json',
+                'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.content || ''
+            }
+        })
+        .then(response => response.json())
+        .then(data => {
+            if (data.success) {
+                alert('Pitch deleted successfully!');
+                // Reload the page to refresh the list
+                window.location.reload();
+            } else {
+                alert(data.error || 'Failed to delete pitch');
+            }
+        })
+        .catch(error => {
+            console.error('Error:', error);
+            alert('Failed to delete pitch. Please try again.');
+        });
+    }
+};
+
+// Close modal when clicking outside
+window.onclick = function(event) {
+    const modal = document.getElementById('pitchViewModal');
+    if (event.target === modal) {
+        closePitchModal();
+    }
+};

--- a/public/js/admin/projects.js
+++ b/public/js/admin/projects.js
@@ -1,6 +1,97 @@
 document.addEventListener("DOMContentLoaded", function () {
+    // View Project Function
+    window.viewProject = function(projectId) {
+        fetch(`/admin/projects/${projectId}/view`, {
+            method: 'GET',
+            headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json',
+                'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.content || ''
+            }
+        })
+        .then(response => response.json())
+        .then(data => {
+            if (data.success) {
+                const project = data.project;
+                const progress = project.funding_goal > 0
+                    ? Math.min(100, (project.current_funding / project.funding_goal) * 100)
+                    : 0;
+
+                const modalBody = document.getElementById('projectModalBody');
+                modalBody.innerHTML = `
+                    <div class="pitch-details">
+                        <div class="pitch-header">
+                            <h2>${project.title}</h2>
+                            <span class="status-badge status-${project.status.toLowerCase()}">${project.status}</span>
+                        </div>
+
+                        <div class="pitch-info-grid">
+                            <div class="pitch-info-item">
+                                <label><i class="fas fa-user"></i> Author:</label>
+                                <span>${project.user.first_name} ${project.user.last_name}</span>
+                            </div>
+                            <div class="pitch-info-item">
+                                <label><i class="fas fa-tag"></i> Category:</label>
+                                <span>${project.category || 'N/A'}</span>
+                            </div>
+                            <div class="pitch-info-item">
+                                <label><i class="fas fa-bullseye"></i> Funding Goal:</label>
+                                <span>₱${parseFloat(project.funding_goal).toLocaleString()}</span>
+                            </div>
+                            <div class="pitch-info-item">
+                                <label><i class="fas fa-money-bill-wave"></i> Current Funding:</label>
+                                <span>₱${parseFloat(project.current_funding).toLocaleString()}</span>
+                            </div>
+                            <div class="pitch-info-item">
+                                <label><i class="fas fa-calendar-alt"></i> Start Date:</label>
+                                <span>${new Date(project.start_date).toLocaleDateString()}</span>
+                            </div>
+                            <div class="pitch-info-item">
+                                <label><i class="fas fa-calendar-check"></i> End Date:</label>
+                                <span>${new Date(project.end_date).toLocaleDateString()}</span>
+                            </div>
+                        </div>
+
+                        <div class="pitch-progress">
+                            <label>Funding Progress:</label>
+                            <div class="progress-bar-container">
+                                <div class="progress-bar-fill" style="width: ${progress}%">
+                                    ${progress.toFixed(0)}%
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="pitch-description">
+                            <label><i class="fas fa-file-alt"></i> Description:</label>
+                            <p>${project.description}</p>
+                        </div>
+
+                        <div class="pitch-meta">
+                            <small><i class="fas fa-clock"></i> Created: ${new Date(project.created_at).toLocaleString()}</small>
+                            <small><i class="fas fa-sync"></i> Updated: ${new Date(project.updated_at).toLocaleString()}</small>
+                        </div>
+                    </div>
+                `;
+
+                document.getElementById('projectViewModal').style.display = 'block';
+            } else {
+                alert('Failed to load project details');
+            }
+        })
+        .catch(error => {
+            console.error('Error:', error);
+            alert('Failed to load project details');
+        });
+    };
+
+    // Close Project Modal
+    window.closeProjectModal = function() {
+        document.getElementById('projectViewModal').style.display = 'none';
+    };
+
+    // Delete Project Function
     window.deleteProject = function (projectId) {
-        if (confirm("Are you sure you want to delete this project?")) {
+        if (confirm("Are you sure you want to delete this project? This action cannot be undone.")) {
             fetch(`/admin/projects/${projectId}`, {
                 method: "DELETE",
                 headers: {
@@ -13,15 +104,9 @@ document.addEventListener("DOMContentLoaded", function () {
             .then(response => response.json())
             .then(data => {
                 if (data.success) {
-                    // Find and remove the project row
-                    const row = document.querySelector(`tr:has(button[onclick*="${projectId}"])`);
-                    if (row) {
-                        row.remove();
-                        // Show success message
-                        alert("Project successfully deleted!");
-                        // Optionally reload the page to refresh statistics
-                        window.location.reload();
-                    }
+                    alert("Project successfully deleted!");
+                    // Reload the page to refresh statistics and list
+                    window.location.reload();
                 } else {
                     throw new Error(data.error || 'Failed to delete project');
                 }
@@ -30,6 +115,14 @@ document.addEventListener("DOMContentLoaded", function () {
                 console.error("Error:", error);
                 alert(error.message || "Failed to delete project. Please try again.");
             });
+        }
+    };
+
+    // Close modal when clicking outside
+    window.onclick = function(event) {
+        const modal = document.getElementById('projectViewModal');
+        if (event.target === modal) {
+            closeProjectModal();
         }
     };
 });

--- a/resources/views/admin/admin.blade.php
+++ b/resources/views/admin/admin.blade.php
@@ -1,5 +1,10 @@
 @extends('admin.layout')
 
+@section('styles')
+@parent
+<link rel="stylesheet" href="{{ asset('css/admin/project-modal.css') }}">
+@endsection
+
 @section('content')
 <div class="content-header">
     <div class="container-fluid">
@@ -149,8 +154,127 @@
                 </div>
             </div>
         </div>
+
+        <!-- Recent Activity Section -->
+        <div class="stats-row" style="margin-top: 30px;">
+            <!-- Recent Users -->
+            <div class="stats-category" style="width: 48%;">
+                <div class="category-header">
+                    <h4 class="category-title">
+                        <i class="mdi mdi-account-multiple"></i>
+                        Recent Users
+                    </h4>
+                </div>
+                <div class="table-container">
+                    <div class="table-responsive">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Name</th>
+                                    <th>Type</th>
+                                    <th>Email</th>
+                                    <th>Joined</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @forelse($recentUsers as $user)
+                                <tr>
+                                    <td>
+                                        <div class="user-info">
+                                            <i class="fas fa-user-circle"></i>
+                                            <span>{{ $user->first_name }} {{ $user->last_name }}</span>
+                                        </div>
+                                    </td>
+                                    <td>
+                                        <span class="status-badge status-{{ strtolower($user->user_type) }}">
+                                            {{ $user->user_type }}
+                                        </span>
+                                    </td>
+                                    <td>{{ $user->email }}</td>
+                                    <td>{{ $user->created_at->diffForHumans() }}</td>
+                                </tr>
+                                @empty
+                                <tr>
+                                    <td colspan="4" class="text-center">No recent users</td>
+                                </tr>
+                                @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Recent Pitches -->
+            <div class="stats-category" style="width: 48%;">
+                <div class="category-header">
+                    <h4 class="category-title">
+                        <i class="mdi mdi-briefcase"></i>
+                        Recent Pitches
+                    </h4>
+                </div>
+                <div class="table-container">
+                    <div class="table-responsive">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Title</th>
+                                    <th>Author</th>
+                                    <th>Status</th>
+                                    <th>Actions</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @forelse($recentPitches as $pitch)
+                                <tr>
+                                    <td>
+                                        <div class="project-info">
+                                            <i class="fas fa-briefcase project-icon"></i>
+                                            <span>{{ Str::limit($pitch->title, 30) }}</span>
+                                        </div>
+                                    </td>
+                                    <td>{{ $pitch->user->first_name }} {{ $pitch->user->last_name }}</td>
+                                    <td>
+                                        <span class="status-badge status-{{ strtolower($pitch->status) }}">
+                                            {{ $pitch->status }}
+                                        </span>
+                                    </td>
+                                    <td>
+                                        <div class="action-buttons">
+                                            <button class="view-btn" title="View Pitch" onclick="viewPitch({{ $pitch->id }})">
+                                                <i class="mdi mdi-eye"></i>
+                                            </button>
+                                            <button class="delete-btn" title="Delete Pitch" onclick="deletePitch({{ $pitch->id }})">
+                                                <i class="mdi mdi-delete"></i>
+                                            </button>
+                                        </div>
+                                    </td>
+                                </tr>
+                                @empty
+                                <tr>
+                                    <td colspan="4" class="text-center">No recent pitches</td>
+                                </tr>
+                                @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 </section>
+
+<!-- Pitch View Modal -->
+<div id="pitchViewModal" class="modal" style="display: none;">
+    <div class="modal-content" style="max-width: 800px;">
+        <div class="modal-header">
+            <h3><i class="mdi mdi-briefcase"></i> Pitch Details</h3>
+            <span class="close" onclick="closePitchModal()">&times;</span>
+        </div>
+        <div class="modal-body" id="pitchModalBody">
+            <!-- Content will be loaded dynamically -->
+        </div>
+    </div>
+</div>
 
 <script>
     var statisticsData = {

--- a/resources/views/admin/projects.blade.php
+++ b/resources/views/admin/projects.blade.php
@@ -5,6 +5,8 @@
 <link rel="stylesheet" href="{{ asset('css/admin/admin.css') }}">
 <!-- Projects specific CSS -->
 <link rel="stylesheet" href="{{ asset('css/admin/projects.css') }}">
+<!-- Project Modal CSS -->
+<link rel="stylesheet" href="{{ asset('css/admin/project-modal.css') }}">
 <!-- Material Design Icons -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@6.5.95/css/materialdesignicons.min.css">
 <!-- Font Awesome -->
@@ -140,8 +142,8 @@
                 </td>
                 <td>
                   <div class="action-buttons">
-                    <button class="edit-btn" title="Edit Project" onclick="editProject({{ $project->id }})">
-                      <i class="mdi mdi-pencil"></i>
+                    <button class="view-btn" title="View Project" onclick="viewProject({{ $project->id }})">
+                      <i class="mdi mdi-eye"></i>
                     </button>
                     <button class="delete-btn" title="Delete Project" onclick="deleteProject({{ $project->id }})">
                         <i class="mdi mdi-delete"></i>
@@ -161,6 +163,19 @@
     </div>
   </div>
 </section>
+
+<!-- Project View Modal -->
+<div id="projectViewModal" class="modal" style="display: none;">
+  <div class="modal-content" style="max-width: 800px;">
+    <div class="modal-header">
+      <h3><i class="mdi mdi-briefcase"></i> Project Details</h3>
+      <span class="close" onclick="closeProjectModal()">&times;</span>
+    </div>
+    <div class="modal-body" id="projectModalBody">
+      <!-- Content will be loaded dynamically -->
+    </div>
+  </div>
+</div>
 @endsection
 
 @section('scripts')

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -11,6 +11,7 @@ Route::prefix('admin')->middleware(['auth', 'admin'])->group(function () {
     Route::put('/users', [AdminController::class, 'updateUser'])->name('admin.users.update');
     Route::delete('/users/{user}', [AdminController::class, 'deleteUser'])->name('admin.users.delete');
     Route::get('/projects', [AdminController::class, 'projects'])->name('admin.projects');
+    Route::get('/projects/{id}/view', [AdminController::class, 'viewPitch'])->name('admin.projects.view');
     Route::get('/transactions', [AdminController::class, 'transactions'])->name('admin.transactions');
     Route::post('/logout', [AdminController::class, 'logout'])->name('admin.logout');
 });


### PR DESCRIPTION
- Add Recent Users and Recent Pitches sections to admin dashboard
- Implement pitch/project viewing modal for admins with full details
- Add view and delete functionality for pitches in both dashboard and projects page
- Update AdminController to fetch recent users and pitches data
- Create viewPitch endpoint to return pitch details via API
- Add comprehensive modal styling with responsive design
- Ensure delete functionality auto-removes pitches from feed with page reload
- Admin can only view and delete pitches, no interaction like investors

Changes:
- AdminController: Added recentUsers and recentPitches to dashboard(), added viewPitch() method
- admin.blade.php: Added Recent Users and Recent Pitches sections with action buttons
- projects.blade.php: Replaced edit button with view button
- admin-dashboard.js: Added viewPitch(), closePitchModal(), deletePitch() functions
- projects.js: Added viewProject(), closeProjectModal(), deleteProject() functions
- project-modal.css: Created comprehensive modal and component styling
- admin.php routes: Added /projects/{id}/view route